### PR TITLE
Feature/project stuff

### DIFF
--- a/MPower/.gitignore
+++ b/MPower/.gitignore
@@ -52,6 +52,9 @@ tasks.xml
 .idea/modules.xml
 .iml
 
+# We do all project config in gradle, so don't need anything in .idea
+.idea/*
+
 # CDT-specific
 */.cproject
 

--- a/MPower/build.gradle
+++ b/MPower/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'me.tatarka:gradle-retrolambda:3.2.3'


### PR DESCRIPTION
lets just ignore the whole .idea directory.

We don't need gradle.xml since we aren't trying to keep settings synced between all of us. I'm also getting random auto changes there, like a value for gradleHome. Also other files created like vcs.xml.

Updates the gradle tools to the latest version as well